### PR TITLE
User can use drop-down list to move books to different shelves.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,20 @@ export default class BooksApp extends Component {
       .then(books => this.setState({ books }))
       .catch(err => console.error(err))
   }
+  updateBookStatus = (book, shelf) => {
+    this.setState(state => ({
+      books: [
+        ...state.books.filter(b => b.id !== book.id),
+        {
+          ...state.books.find(b => b.id === book.id),
+          ...{ shelf }
+        }
+      ]
+    }))
+
+    BooksAPI.update(book, shelf)
+      .catch(err => console.error(err))
+  }
 
   render() {
     return (
@@ -23,7 +37,7 @@ export default class BooksApp extends Component {
           <Search />
         )}/>
         <Route exact path='/' render={() => (
-          <Bookcase books={this.state.books} />
+          <Bookcase books={this.state.books} onSelect={this.updateBookStatus}/>
         )}/>
       </div>
     )

--- a/src/Book.js
+++ b/src/Book.js
@@ -1,33 +1,41 @@
-import React from 'react'
+import React, { Component } from 'react'
 
-const Book = props => {
+export default class Book extends Component {
 
-  const { author, cover, title } = props
+  state = {
+    value: 'unselected'
+  }
 
-  return (
-    <li>
-      <div className="book">
-        <div className="book-top">
-          <div className="book-cover" style={{
-            width: 128,
-            height: 193,            
-            backgroundImage: `url(${cover})`
-          }}></div>
-          <div className="book-shelf-changer">
-            <select>
-              <option value="none" disabled>Move to...</option>
-              <option value="currentlyReading">Currently Reading</option>
-              <option value="wantToRead">Want to Read</option>
-              <option value="read">Read</option>
-              <option value="none">None</option>
-            </select>
+  handleChange = value => {
+    this.setState({ value })
+    this.props.onSelect({id: this.props.id}, value)
+  }
+  render() {
+    const { author, cover, title } = this.props
+
+    return (
+      <li>
+        <div className="book">
+          <div className="book-top">
+            <div className="book-cover" style={{
+              width: 128,
+              height: 193,            
+              backgroundImage: `url(${cover})`
+            }}></div>
+            <div className="book-shelf-changer">
+              <select value={this.state.value} onChange={({ target }) => this.handleChange(target.value)}>
+                <option value="unselected" disabled>Move to...</option>
+                <option value="currentlyReading">Currently Reading</option>
+                <option value="wantToRead">Want to Read</option>
+                <option value="read">Read</option>
+                <option value="none">None</option>
+              </select>
+            </div>
           </div>
+          <div className="book-title">{title}</div>
+          <div className="book-authors">{author}</div>
         </div>
-        <div className="book-title">{title}</div>
-        <div className="book-authors">{author}</div>
-      </div>
-    </li>
-  )
+      </li>
+    )
+  }
 }
-
-export default Book

--- a/src/Bookcase.js
+++ b/src/Bookcase.js
@@ -33,6 +33,7 @@ export default class Bookcase extends Component {
                 key={shelf.id}
                 title={shelf.title}
                 books={this.props.books.filter(book => book.shelf === shelf.id)}
+                onSelect={this.props.onSelect}
               />
             })}
           </div>

--- a/src/Shelf.js
+++ b/src/Shelf.js
@@ -3,7 +3,7 @@ import Book from './Book'
 
 const Shelf = props => {
 
-  const { title, books } = props
+  const { title, books, onSelect } = props
 
   return (   
     <div className="bookshelf">
@@ -13,9 +13,11 @@ const Shelf = props => {
           {books.map(book =>
             <Book
               key={book.id}
+              id={book.id}
               author={book.author}
               cover={book.imageLinks.smallThumbnail}
               title={book.title}
+              onSelect={onSelect}
             />
           )}
         </ol>


### PR DESCRIPTION
This pull request will complete issue #7, allowing users to move books to different shelves. When they are moved a request it sent to the Udacity API to update the `shelf` property of the book object in the database, making sure the user's data is persistent.   